### PR TITLE
Add Mumbai with Kolkata's details

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -21,7 +21,7 @@ var cityOptions = {
   "moscow":        ["Moscow",        "Europe/Moscow"],
   "dubai":         ["Dubai",         "Asia/Dubai"],
   "colombo":       ["Colombo",       "Asia/Colombo"],
-  "mumbai":        ["Mumbai",        "Asia/Colombo"], // <-- Don't think using Colombo for Mumbai is robust.
+  "mumbai":        ["Mumbai",        "Asia/Kolkata"],
   "dhaka":         ["Dhaka",         "Asia/Dhaka"],
   "bangkok":       ["Bangkok",       "Asia/Bangkok"],
   "singapore":     ["Singapore",     "Asia/Singapore"],

--- a/assets/app.js
+++ b/assets/app.js
@@ -21,6 +21,7 @@ var cityOptions = {
   "moscow":        ["Moscow",        "Europe/Moscow"],
   "dubai":         ["Dubai",         "Asia/Dubai"],
   "colombo":       ["Colombo",       "Asia/Colombo"],
+  "mumbai":        ["Mumbai",        "Asia/Colombo"], // <-- Don't think using Colombo for Mumbai is robust.
   "dhaka":         ["Dhaka",         "Asia/Dhaka"],
   "bangkok":       ["Bangkok",       "Asia/Bangkok"],
   "singapore":     ["Singapore",     "Asia/Singapore"],


### PR DESCRIPTION
Fixes #13.

I did some digging. [Moment Timezone](http://momentjs.com/timezone/) uses [this timezone database](http://www.iana.org/time-zones) and according to [this](http://grokbase.com/t/perl/datetime/128heb2gan/is-there-timezone-data-for-any-indian-cities-such-as-mumbai-dehli-c), the only Indian city is `Asia/Kolkata`. It's a shame some cities aren't included but I have added Mumbai using Kolkata's reference.

``` javascript
"mumbai": ["Mumbai", "Asia/Kolkata"],
```
